### PR TITLE
Replace echo servers with real applications in integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,13 +33,16 @@ jobs:
         with:
           terraform_wrapper: false
 
+      - name: Install test dependencies
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client dnsutils
+
       - name: Configure hostname resolution
         run: echo "127.0.0.1 nb-server" | sudo tee -a /etc/hosts
 
       - name: Start infrastructure and seed database
         working-directory: integration
         run: |
-          docker compose up -d netbird-server echo-server echo-tcp echo-udp echo-tls
+          docker compose up -d netbird-server nginx postgres coredns
           docker compose up netbird-setup --exit-code-from netbird-setup
 
       - name: Apply Terraform

--- a/app/admin_test.go
+++ b/app/admin_test.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		b    int64
+		want string
+	}{
+		{"zero", 0, "0 B"},
+		{"bytes", 512, "512 B"},
+		{"one KiB", 1024, "1.0 KiB"},
+		{"KiB", 1536, "1.5 KiB"},
+		{"one MiB", 1 << 20, "1.0 MiB"},
+		{"MiB", 5 * (1 << 20), "5.0 MiB"},
+		{"one GiB", 1 << 30, "1.0 GiB"},
+		{"GiB", 3 * (1 << 30), "3.0 GiB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatBytes(tt.b))
+		})
+	}
+}
+
+func TestConnectedStr(t *testing.T) {
+	assert.Equal(t, "Connected", connectedStr(true))
+	assert.Equal(t, "Disconnected", connectedStr(false))
+}
+
+func TestICMPChecksum(t *testing.T) {
+	// Standard ICMP echo request: type=8, code=0, checksum=0, id=0, seq=0
+	data := make([]byte, 8)
+	data[0] = 8 // Echo request
+
+	hi, lo := icmpChecksum(data)
+	data[2], data[3] = hi, lo
+
+	// Verify: recomputing checksum over the packet with checksum filled in should yield 0.
+	var sum uint32
+	for i := 0; i < len(data)-1; i += 2 {
+		sum += uint32(data[i])<<8 | uint32(data[i+1])
+	}
+	for sum>>16 != 0 {
+		sum = (sum & 0xFFFF) + (sum >> 16)
+	}
+	assert.Equal(t, uint16(0xFFFF), uint16(sum), "checksum verification should produce 0xFFFF")
+}
+
+func TestICMPChecksum_OddLength(t *testing.T) {
+	data := []byte{8, 0, 0, 0, 0, 0, 0}
+	hi, lo := icmpChecksum(data)
+
+	// Verify by recomputing with checksum set
+	data[2], data[3] = hi, lo
+	var sum uint32
+	for i := 0; i < len(data)-1; i += 2 {
+		sum += uint32(data[i])<<8 | uint32(data[i+1])
+	}
+	sum += uint32(data[len(data)-1]) << 8
+	for sum>>16 != 0 {
+		sum = (sum & 0xFFFF) + (sum >> 16)
+	}
+	assert.Equal(t, uint16(0xFFFF), uint16(sum), "odd-length checksum verification should produce 0xFFFF")
+}
+
+func TestSortedKeys(t *testing.T) {
+	m := map[string]struct{}{
+		"charlie": {},
+		"alpha":   {},
+		"bravo":   {},
+	}
+	assert.Equal(t, []string{"alpha", "bravo", "charlie"}, sortedKeys(m))
+}
+
+func TestSortedKeys_Empty(t *testing.T) {
+	assert.Empty(t, sortedKeys(nil))
+}

--- a/integration/Caddyfile
+++ b/integration/Caddyfile
@@ -10,23 +10,23 @@
 		}
 	}
 	layer4 {
-		# TCP echo
-		:9191 {
+		# TCP → postgres
+		:5432 {
 			route {
-				netbird 172.28.0.11:9090 ingress
+				netbird 172.28.0.11:5432 ingress
 			}
 		}
-		# UDP echo
+		# UDP → coredns
 		udp/:9053 {
 			route {
-				netbird 172.28.0.12:9053 ingress
+				netbird 172.28.0.12:53 ingress
 			}
 		}
-		# SNI TLS passthrough
+		# SNI TLS passthrough → nginx HTTPS
 		:4443 {
 			@echotls tls sni echo-tls.test
 			route @echotls {
-				netbird 172.28.0.13:4443 ingress
+				netbird 172.28.0.10:8443 ingress
 			}
 		}
 	}

--- a/integration/Corefile
+++ b/integration/Corefile
@@ -1,0 +1,8 @@
+test.local:53 {
+    hosts {
+        10.0.0.1 app.test.local
+        10.0.0.2 db.test.local
+        fallthrough
+    }
+    log
+}

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -25,39 +25,39 @@ services:
       - ./setup.sh:/setup.sh:ro
     entrypoint: ["bash", "/setup.sh"]
 
-  echo-server:
-    image: hashicorp/http-echo:latest
-    command: ["-text=echo-ok", "-listen=:8080"]
-    networks:
-      backend:
-        ipv4_address: 172.28.0.10
-
-  echo-tcp:
-    image: alpine/socat:latest
-    command: ["TCP-LISTEN:9090,fork,reuseaddr", "EXEC:/bin/cat"]
-    networks:
-      backend:
-        ipv4_address: 172.28.0.11
-
-  echo-udp:
-    image: alpine/socat:latest
-    command: ["UDP-RECVFROM:9053,fork,reuseaddr", "EXEC:/bin/cat"]
-    networks:
-      backend:
-        ipv4_address: 172.28.0.12
-
-  echo-tls:
-    image: alpine:latest
+  nginx:
+    image: nginx:alpine
     command:
       - sh
       - -c
       - |
-        apk add --no-cache openssl socat &&
-        openssl req -x509 -newkey rsa:2048 -keyout /tmp/key.pem -out /tmp/cert.pem -days 1 -nodes -subj '/CN=echo-tls.test' &&
-        socat OPENSSL-LISTEN:4443,fork,reuseaddr,cert=/tmp/cert.pem,key=/tmp/key.pem,verify=0 EXEC:'/bin/cat'
+        apk add --no-cache openssl &&
+        mkdir -p /etc/nginx/ssl &&
+        openssl req -x509 -newkey rsa:2048 -keyout /etc/nginx/ssl/key.pem -out /etc/nginx/ssl/cert.pem -days 1 -nodes -subj '/CN=echo-tls.test' &&
+        nginx -g 'daemon off;'
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     networks:
       backend:
-        ipv4_address: 172.28.0.13
+        ipv4_address: 172.28.0.10
+
+  postgres:
+    image: postgres:alpine
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: testdb
+    networks:
+      backend:
+        ipv4_address: 172.28.0.11
+
+  coredns:
+    image: coredns/coredns
+    volumes:
+      - ./Corefile:/Corefile:ro
+    networks:
+      backend:
+        ipv4_address: 172.28.0.12
 
   routing-peer:
     image: netbirdio/netbird:latest

--- a/integration/nginx.conf
+++ b/integration/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 8080;
+
+    location / {
+        default_type application/json;
+        return 200 '{"status":"ok","server":"nginx"}';
+    }
+
+    location /health {
+        default_type text/plain;
+        return 200 'healthy';
+    }
+}
+
+server {
+    listen 8443 ssl;
+    server_name echo-tls.test;
+
+    ssl_certificate /etc/nginx/ssl/cert.pem;
+    ssl_certificate_key /etc/nginx/ssl/key.pem;
+
+    location / {
+        default_type application/json;
+        return 200 '{"status":"ok","server":"nginx-tls"}';
+    }
+}

--- a/integration/tests/proxy.robot
+++ b/integration/tests/proxy.robot
@@ -68,6 +68,12 @@ Admin Ping UDP
     ${resp}=    POST    url=${PING_URL}    json=${body}    expected_status=200
     Should Be True    ${resp.json()}[reachable]    UDP ping should report reachable
 
+Admin Ping ICMP
+    [Documentation]    Verify ICMP ping through NetBird tunnel via admin API
+    ${body}=    Create Dictionary    node=ingress    address=${NGINX_IP}    network=ping
+    ${resp}=    POST    url=${PING_URL}    json=${body}    expected_status=200
+    Should Be True    ${resp.json()}[reachable]    ICMP ping should report reachable
+
 HTTP Reverse Proxy Returns Nginx JSON
     [Documentation]    HTTP request through Caddy reverse proxy via NetBird tunnel to nginx
     Wait Until Keyword Succeeds    30 sec    2 sec    Verify HTTP Proxy Response

--- a/integration/tests/proxy.robot
+++ b/integration/tests/proxy.robot
@@ -10,11 +10,11 @@ Suite Setup    Wait For NetBird Connection
 ${CADDY_ADMIN}       http://localhost:2019
 ${CADDY_HTTP}        http://localhost:8088
 ${CADDY_L4_HOST}     localhost
-${CADDY_L4_TCP}      9191
+${CADDY_L4_TCP}      5432
 ${CADDY_L4_UDP}      9053
 ${CADDY_L4_SNI}      4443
-${ECHO_SERVER_IP}    172.28.0.10
-${ECHO_UDP_IP}       172.28.0.12
+${NGINX_IP}          172.28.0.10
+${COREDNS_IP}        172.28.0.12
 ${STATUS_URL}        http://localhost:2019/netbird/status
 ${PING_URL}          http://localhost:2019/netbird/ping
 ${LOG_LEVEL_URL}     http://localhost:2019/netbird/log-level
@@ -58,37 +58,56 @@ Admin Set Log Level
 
 Admin Ping TCP
     [Documentation]    Verify TCP ping through NetBird tunnel via admin API
-    ${body}=    Create Dictionary    node=ingress    address=${ECHO_SERVER_IP}:8080    network=tcp
+    ${body}=    Create Dictionary    node=ingress    address=${NGINX_IP}:8080    network=tcp
     ${resp}=    POST    url=${PING_URL}    json=${body}    expected_status=200
     Should Be True    ${resp.json()}[reachable]    TCP ping should report reachable
 
 Admin Ping UDP
     [Documentation]    Verify UDP ping through NetBird tunnel via admin API
-    ${body}=    Create Dictionary    node=ingress    address=${ECHO_UDP_IP}:9053    network=udp
+    ${body}=    Create Dictionary    node=ingress    address=${COREDNS_IP}:53    network=udp
     ${resp}=    POST    url=${PING_URL}    json=${body}    expected_status=200
     Should Be True    ${resp.json()}[reachable]    UDP ping should report reachable
 
-HTTP Reverse Proxy Through NB Tunnel
-    [Documentation]    HTTP request through Caddy reverse proxy via NetBird tunnel
+HTTP Reverse Proxy Returns Nginx JSON
+    [Documentation]    HTTP request through Caddy reverse proxy via NetBird tunnel to nginx
     Wait Until Keyword Succeeds    30 sec    2 sec    Verify HTTP Proxy Response
+
+HTTP Reverse Proxy Health Endpoint
+    [Documentation]    Verify the nginx /health endpoint through the tunnel
+    ${resp}=    GET    url=${CADDY_HTTP}/health    expected_status=200
+    Should Contain    ${resp.text}    healthy
 
 HTTP Reverse Proxy Multiple Requests
     [Documentation]    Verify multiple sequential requests work through the tunnel
     FOR    ${i}    IN RANGE    5
         ${resp}=    GET    url=${CADDY_HTTP}    expected_status=200
-        Should Contain    ${resp.text}    echo-ok
+        Should Contain    ${resp.text}    nginx
     END
 
-L4 TCP Proxy Through NB Tunnel
-    [Documentation]    Raw TCP echo through Caddy L4 proxy via NetBird tunnel
-    Wait Until Keyword Succeeds    30 sec    2 sec    Verify TCP Proxy Echo
+L4 TCP Proxy PostgreSQL Query
+    [Documentation]    PostgreSQL query through Caddy L4 TCP proxy via NetBird tunnel
+    Wait Until Keyword Succeeds    30 sec    2 sec    Verify PostgreSQL Connection
 
-L4 UDP Proxy Through NB Tunnel
-    [Documentation]    UDP echo through Caddy L4 proxy via NetBird tunnel
-    Wait Until Keyword Succeeds    30 sec    2 sec    Verify UDP Proxy Echo
+L4 TCP Proxy PostgreSQL Write And Read
+    [Documentation]    Verify write and read through PostgreSQL via the tunnel
+    ${result}=    Run Process    bash    -c
+    ...    PGPASSWORD\=test psql -h ${CADDY_L4_HOST} -p ${CADDY_L4_TCP} -U test -d testdb -t -A -c "CREATE TABLE IF NOT EXISTS integration_test (id serial, name text); INSERT INTO integration_test (name) VALUES ('hello'); SELECT name FROM integration_test LIMIT 1;"
+    Should Be Equal As Integers    ${result.rc}    0    psql write/read failed: ${result.stderr}
+    Should Contain    ${result.stdout}    hello
+
+L4 UDP Proxy DNS Query
+    [Documentation]    DNS query through Caddy L4 UDP proxy via NetBird tunnel to CoreDNS
+    Wait Until Keyword Succeeds    30 sec    2 sec    Verify DNS Query App
+
+L4 UDP Proxy DNS Query Second Record
+    [Documentation]    Verify a second DNS record resolves through the tunnel
+    ${result}=    Run Process    bash    -c
+    ...    dig @${CADDY_L4_HOST} -p ${CADDY_L4_UDP} db.test.local A +short
+    Should Be Equal As Integers    ${result.rc}    0    dig command failed: ${result.stderr}
+    Should Contain    ${result.stdout}    10.0.0.2
 
 L4 SNI TLS Passthrough
-    [Documentation]    TLS passthrough via SNI routing through NetBird tunnel
+    [Documentation]    TLS passthrough via SNI routing through NetBird tunnel to nginx HTTPS
     Wait Until Keyword Succeeds    60 sec    5 sec    Verify SNI TLS Passthrough
 
 *** Keywords ***
@@ -109,20 +128,22 @@ NetBird Client Connected
 
 Verify HTTP Proxy Response
     ${resp}=    GET    url=${CADDY_HTTP}    expected_status=200
-    Should Contain    ${resp.text}    echo-ok
+    Should Contain    ${resp.text}    nginx
 
-Verify TCP Proxy Echo
+Verify PostgreSQL Connection
     ${result}=    Run Process    bash    -c
-    ...    echo "hello-tcp" | nc -w 5 ${CADDY_L4_HOST} ${CADDY_L4_TCP}
-    Should Be Equal As Integers    ${result.rc}    0    nc command failed
-    Should Contain    ${result.stdout}    hello-tcp
+    ...    PGPASSWORD\=test psql -h ${CADDY_L4_HOST} -p ${CADDY_L4_TCP} -U test -d testdb -t -A -c "SELECT 1"
+    Should Be Equal As Integers    ${result.rc}    0    psql command failed: ${result.stderr}
+    Should Contain    ${result.stdout}    1
 
-Verify UDP Proxy Echo
+Verify DNS Query App
     ${result}=    Run Process    bash    -c
-    ...    echo "hello-udp" | nc -u -w 2 ${CADDY_L4_HOST} ${CADDY_L4_UDP}
-    Should Contain    ${result.stdout}    hello-udp
+    ...    dig @${CADDY_L4_HOST} -p ${CADDY_L4_UDP} app.test.local A +short
+    Should Be Equal As Integers    ${result.rc}    0    dig command failed: ${result.stderr}
+    Should Contain    ${result.stdout}    10.0.0.1
 
 Verify SNI TLS Passthrough
     ${result}=    Run Process    bash    -c
-    ...    (echo "hello-sni"; sleep 1) | timeout 5 openssl s_client -connect ${CADDY_L4_HOST}:${CADDY_L4_SNI} -servername echo-tls.test -quiet 2>/dev/null
-    Should Contain    ${result.stdout}    hello-sni
+    ...    curl -sk --resolve echo-tls.test:${CADDY_L4_SNI}:127.0.0.1 https://echo-tls.test:${CADDY_L4_SNI}/
+    Should Be Equal As Integers    ${result.rc}    0    curl command failed: ${result.stderr}
+    Should Contain    ${result.stdout}    nginx-tls


### PR DESCRIPTION
Swap out simple echo services (http-echo, socat) for real applications (nginx, PostgreSQL, CoreDNS) to validate that actual protocol behavior works end-to-end through the NetBird tunnel.