### PR TITLE
Bump netbird to v0.66.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/caddyserver/caddy/v2 v2.11.1
 	github.com/mholt/caddy-l4 v0.0.0-20260216070754-eca560d759c9
-	github.com/netbirdio/netbird v0.66.5-0.20260317050912-4e149c9222aa
+	github.com/netbirdio/netbird v0.66.4
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ github.com/netbirdio/ice/v4 v4.0.0-20250908184934-6202be846b51 h1:Ov4qdafATOgGMB
 github.com/netbirdio/ice/v4 v4.0.0-20250908184934-6202be846b51/go.mod h1:ZSIbPdBn5hePO8CpF1PekH2SfpTxg1PDhEwtbqZS7R8=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260210160626-df4b180c7b25 h1:iwAq/Ncaq0etl4uAlVsbNBzC1yY52o0AmY7uCm2AMTs=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260210160626-df4b180c7b25/go.mod h1:y7CxagMYzg9dgu+masRqYM7BQlOGA5Y8US85MCNFPlY=
-github.com/netbirdio/netbird v0.66.5-0.20260317050912-4e149c9222aa h1:U4hCP2bnrzZLsYVPv+yiXdFOZ5lEzeVHDalasSI/SNw=
-github.com/netbirdio/netbird v0.66.5-0.20260317050912-4e149c9222aa/go.mod h1:212w9p2F15XN0Gpd3c9+tEpuUejTqZjm2OCK02XRJrc=
+github.com/netbirdio/netbird v0.66.4 h1:jZt9e4yDjeBybLPcW4SQhhlsn15o2Jx0OzVPM9RY8mE=
+github.com/netbirdio/netbird v0.66.4/go.mod h1:Yeh8fZDsfngjcWedgGrzLKzsxKbGw2dQBOrJpLntpiw=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45 h1:ujgviVYmx243Ksy7NdSwrdGPSRNE3pb8kEDSpH0QuAQ=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45/go.mod h1:5/sjFmLb8O96B5737VCqhHyGRzNFIaN/Bu7ZodXc3qQ=
 github.com/netbirdio/wireguard-go v0.0.0-20260107100953-33b7c9d03db0 h1:h/QnNzm7xzHPm+gajcblYUOclrW2FeNeDlUNj6tTWKQ=


### PR DESCRIPTION
Automated NetBird dependency update to v0.66.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency version for compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->