### PR TITLE
Add dns_labels node option for extra DNS labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Multiple sites can share the same NetBird client by referencing the same node na
 | `pre_shared_key` | Pre-shared key for the network interface |
 | `wireguard_port` | Port for the network interface (default: 51820 via NetBird) |
 | `block_inbound` | Block inbound connections from peers (default: `true`). Set to `false` for egress nodes |
+| `dns_labels` | Additional DNS labels for the peer (space-separated list) |
 
 > **Note on `wireguard_port`:** For reliable peer-to-peer connectivity, the configured port (or the default random port) should be exposed via port forwarding on the host's firewall/NAT. Without it, connections may fall back to relayed traffic which adds latency.
 

--- a/app/app.go
+++ b/app/app.go
@@ -181,6 +181,8 @@ func (a *App) LookupClient(nodeName string) (*ManagedClient, bool) {
 	return mc, mc != nil
 }
 
+// newManagedClient resolves the named node's config, builds the NetBird
+// embed.Options, and constructs a ManagedClient for it.
 func (a *App) newManagedClient(nodeName string) (*ManagedClient, error) {
 	node := a.resolveNode(nodeName)
 

--- a/app/app.go
+++ b/app/app.go
@@ -72,6 +72,8 @@ type Node struct {
 	// Defaults to true. Set to false for egress nodes that accept
 	// connections from other NetBird peers.
 	BlockInbound *bool `json:"block_inbound,omitempty"`
+	// DNSLabels defines additional DNS labels configured in the peer.
+	DNSLabels []string `json:"dns_labels,omitempty"`
 }
 
 // CaddyModule returns the Caddy module information.
@@ -195,6 +197,7 @@ func (a *App) newManagedClient(nodeName string) (*ManagedClient, error) {
 		BlockInbound:  blockInbound,
 		PreSharedKey:  node.PreSharedKey,
 		WireguardPort: node.WireguardPort,
+		DNSLabels:     node.DNSLabels,
 	}
 
 	client, err := embed.New(opts)
@@ -390,6 +393,13 @@ func parseNode(d *caddyfile.Dispenser) (*Node, error) {
 				return nil, d.Errf("invalid block_inbound: %v", err)
 			}
 			node.BlockInbound = &val
+
+		case "dns_labels":
+			labels := d.RemainingArgs()
+			if len(labels) == 0 {
+				return nil, d.ArgErr()
+			}
+			node.DNSLabels = labels
 
 		default:
 			return nil, d.Errf("unrecognized node option: %s", d.Val())

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -105,6 +105,7 @@ func TestParseGlobalOption_NodeAllOptions(t *testing.T) {
 			hostname my-caddy
 			pre_shared_key secret
 			wireguard_port 51821
+			dns_labels app db cache
 		}
 	}`)
 
@@ -116,6 +117,7 @@ func TestParseGlobalOption_NodeAllOptions(t *testing.T) {
 	assert.Equal(t, "secret", node.PreSharedKey)
 	require.NotNil(t, node.WireguardPort)
 	assert.Equal(t, 51821, *node.WireguardPort)
+	assert.Equal(t, []string{"app", "db", "cache"}, node.DNSLabels)
 }
 
 func TestParseGlobalOption_UnknownOption(t *testing.T) {


### PR DESCRIPTION
Expose embed.Options.DNSLabels as a per-node dns_labels directive so peers can advertise additional DNS labels. Accepts a space-separated list in the node block.

The reasoning for this PR is that I'm using an ephemeral setup key and everytime I restart caddy, it gets assigned a new random hostname. So this allows to set a fixed DNS label that I can reach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring multiple additional DNS labels for a peer via the `dns_labels` node setting.
  - Labels are provided as space-separated values in the node configuration and are applied to the managed client.

- **Documentation**
  - Updated the Node options reference to include the new `dns_labels` option (additional space-separated DNS labels for the peer).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->