### PR TITLE
Expose full set of NetBird embed.Options as node options

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,10 +270,25 @@ Multiple sites can share the same NetBird client by referencing the same node na
 |--------|-------------|
 | `management_url` | Override app-level management URL |
 | `setup_key` | Override app-level setup key |
+| `jwt_token` | JWT-based authentication instead of a setup key |
+| `private_key` | Direct private key authentication instead of a setup key |
 | `hostname` | Device name in the NetBird network (default: `caddy-<node>`) |
 | `pre_shared_key` | Pre-shared key for the network interface |
+| `log_level` | Log level for this client (e.g. `debug`, `info`, `warn`) |
+| `config_path` | Path to the NetBird config file (in-memory if unset) |
+| `state_path` | Path to the NetBird state file |
 | `wireguard_port` | Port for the network interface (default: 51820 via NetBird) |
+| `mtu` | MTU for the network interface (valid range 576..8192) |
+| `no_userspace` | Disable userspace networking mode (`true`/`false`, needs root) |
+| `disable_client_routes` | Disable client routes (`true`/`false`) |
+| `disable_ipv6` | Disable IPv6 overlay addressing (`true`/`false`) |
 | `block_inbound` | Block inbound connections from peers (default: `true`). Set to `false` for egress nodes |
+| `block_lan_access` | Block the peer from reaching the host's LAN when used as a routing peer (`true`/`false`) |
+| `dns_labels` | Additional DNS labels for the peer (space-separated list) |
+| `preallocated_buffers_per_pool` | Cap the per-tunnel buffer pool (process-global tuning) |
+| `max_batch_size` | Packets read/written per syscall (process-global tuning) |
+
+> **Authentication:** one of `setup_key` (node or app level), `jwt_token`, or `private_key` is required per node.
 
 > **Note on `wireguard_port`:** For reliable peer-to-peer connectivity, the configured port (or the default random port) should be exposed via port forwarding on the host's firewall/NAT. Without it, connections may fall back to relayed traffic which adds latency.
 

--- a/app/app.go
+++ b/app/app.go
@@ -32,7 +32,7 @@ func GlobalApp() *App {
 
 var (
 	ErrMissingManagementURL = errors.New("management_url is required (set on node or app level)")
-	ErrMissingSetupKey      = errors.New("setup_key is required (set on node or app level)")
+	ErrMissingCredentials   = errors.New("one of setup_key, jwt_token, or private_key is required (set on node or app level)")
 )
 
 func init() {
@@ -57,21 +57,56 @@ type App struct {
 }
 
 // Node is the configuration for a single NetBird client identity.
+// The fields mirror the options accepted by the NetBird embedded client
+// (embed.Options).
 type Node struct {
 	// ManagementURL overrides the app-level default.
 	ManagementURL string `json:"management_url,omitempty"`
-	// SetupKey overrides the app-level default.
+	// SetupKey overrides the app-level default. One of SetupKey,
+	// JWTToken, or PrivateKey must be set (directly or via the
+	// app-level default setup key).
 	SetupKey string `json:"setup_key,omitempty"`
+	// JWTToken is used for JWT-based authentication instead of a setup key.
+	JWTToken string `json:"jwt_token,omitempty"`
+	// PrivateKey is used for direct private key authentication instead of a setup key.
+	PrivateKey string `json:"private_key,omitempty"`
 	// Hostname is the device name registered in the NetBird network.
 	Hostname string `json:"hostname,omitempty"`
 	// PreSharedKey is the pre-shared key for the network interface.
 	PreSharedKey string `json:"pre_shared_key,omitempty"`
+	// LogLevel sets the log level for this client (defaults to info if empty).
+	LogLevel string `json:"log_level,omitempty"`
+	// ConfigPath is the path to the NetBird config file. If empty, the
+	// config is kept in memory and not persisted.
+	ConfigPath string `json:"config_path,omitempty"`
+	// StatePath is the path to the NetBird state file.
+	StatePath string `json:"state_path,omitempty"`
 	// WireguardPort is the port for the network interface. Use 0 for a random port.
 	WireguardPort *int `json:"wireguard_port,omitempty"`
+	// MTU is the MTU for the network interface (valid range 576..8192).
+	// If unset, the existing config MTU is preserved, otherwise it defaults to 1280.
+	MTU *uint16 `json:"mtu,omitempty"`
+	// NoUserspace disables userspace networking mode. Needs admin/root privileges.
+	NoUserspace bool `json:"no_userspace,omitempty"`
+	// DisableClientRoutes disables the client routes.
+	DisableClientRoutes bool `json:"disable_client_routes,omitempty"`
+	// DisableIPv6 disables IPv6 overlay addressing.
+	DisableIPv6 bool `json:"disable_ipv6,omitempty"`
 	// BlockInbound blocks all inbound connections from peers.
 	// Defaults to true. Set to false for egress nodes that accept
 	// connections from other NetBird peers.
 	BlockInbound *bool `json:"block_inbound,omitempty"`
+	// BlockLANAccess blocks the peer from reaching the host's LAN
+	// (RFC 1918, link-local, loopback) when used as a routing peer.
+	BlockLANAccess bool `json:"block_lan_access,omitempty"`
+	// DNSLabels defines additional DNS labels configured in the peer.
+	DNSLabels []string `json:"dns_labels,omitempty"`
+	// PreallocatedBuffersPerPool caps the per-tunnel buffer pool. Zero
+	// leaves the pool unbounded. This setting is process-global.
+	PreallocatedBuffersPerPool *uint32 `json:"preallocated_buffers_per_pool,omitempty"`
+	// MaxBatchSize overrides the number of packets the tunnel reads or
+	// writes per syscall. Zero uses the platform default. Process-global.
+	MaxBatchSize *uint32 `json:"max_batch_size,omitempty"`
 }
 
 // CaddyModule returns the Caddy module information.
@@ -116,8 +151,8 @@ func (a *App) Validate() error {
 		if setupKey == "" {
 			setupKey = a.DefaultSetupKey
 		}
-		if setupKey == "" {
-			return fmt.Errorf("node %q: %w", name, ErrMissingSetupKey)
+		if setupKey == "" && node.JWTToken == "" && node.PrivateKey == "" {
+			return fmt.Errorf("node %q: %w", name, ErrMissingCredentials)
 		}
 	}
 	return nil
@@ -179,6 +214,8 @@ func (a *App) LookupClient(nodeName string) (*ManagedClient, bool) {
 	return mc, mc != nil
 }
 
+// newManagedClient resolves the named node's config, builds the NetBird
+// embed.Options, and constructs a ManagedClient for it.
 func (a *App) newManagedClient(nodeName string) (*ManagedClient, error) {
 	node := a.resolveNode(nodeName)
 
@@ -189,12 +226,27 @@ func (a *App) newManagedClient(nodeName string) (*ManagedClient, error) {
 
 	blockInbound := node.BlockInbound == nil || *node.BlockInbound
 	opts := embed.Options{
-		DeviceName:    hostname,
-		ManagementURL: node.ManagementURL,
-		SetupKey:      node.SetupKey,
-		BlockInbound:  blockInbound,
-		PreSharedKey:  node.PreSharedKey,
-		WireguardPort: node.WireguardPort,
+		DeviceName:          hostname,
+		ManagementURL:       node.ManagementURL,
+		SetupKey:            node.SetupKey,
+		JWTToken:            node.JWTToken,
+		PrivateKey:          node.PrivateKey,
+		PreSharedKey:        node.PreSharedKey,
+		LogLevel:            node.LogLevel,
+		ConfigPath:          node.ConfigPath,
+		StatePath:           node.StatePath,
+		NoUserspace:         node.NoUserspace,
+		DisableClientRoutes: node.DisableClientRoutes,
+		DisableIPv6:         node.DisableIPv6,
+		BlockInbound:        blockInbound,
+		BlockLANAccess:      node.BlockLANAccess,
+		WireguardPort:       node.WireguardPort,
+		MTU:                 node.MTU,
+		DNSLabels:           node.DNSLabels,
+		Performance: embed.Performance{
+			PreallocatedBuffersPerPool: node.PreallocatedBuffersPerPool,
+			MaxBatchSize:               node.MaxBatchSize,
+		},
 	}
 
 	client, err := embed.New(opts)
@@ -220,6 +272,9 @@ func (a *App) resolveNode(name string) Node {
 	}
 	if node.SetupKey == "" {
 		node.SetupKey = a.DefaultSetupKey
+	}
+	if node.LogLevel == "" {
+		node.LogLevel = a.LogLevel
 	}
 	return node
 }
@@ -359,6 +414,18 @@ func parseNode(d *caddyfile.Dispenser) (*Node, error) {
 			}
 			node.SetupKey = d.Val()
 
+		case "jwt_token":
+			if !d.NextArg() {
+				return nil, d.ArgErr()
+			}
+			node.JWTToken = d.Val()
+
+		case "private_key":
+			if !d.NextArg() {
+				return nil, d.ArgErr()
+			}
+			node.PrivateKey = d.Val()
+
 		case "hostname":
 			if !d.NextArg() {
 				return nil, d.ArgErr()
@@ -371,6 +438,24 @@ func parseNode(d *caddyfile.Dispenser) (*Node, error) {
 			}
 			node.PreSharedKey = d.Val()
 
+		case "log_level":
+			if !d.NextArg() {
+				return nil, d.ArgErr()
+			}
+			node.LogLevel = d.Val()
+
+		case "config_path":
+			if !d.NextArg() {
+				return nil, d.ArgErr()
+			}
+			node.ConfigPath = d.Val()
+
+		case "state_path":
+			if !d.NextArg() {
+				return nil, d.ArgErr()
+			}
+			node.StatePath = d.Val()
+
 		case "wireguard_port":
 			if !d.NextArg() {
 				return nil, d.ArgErr()
@@ -380,6 +465,38 @@ func parseNode(d *caddyfile.Dispenser) (*Node, error) {
 				return nil, d.Errf("invalid wireguard_port: %v", err)
 			}
 			node.WireguardPort = &port
+
+		case "mtu":
+			if !d.NextArg() {
+				return nil, d.ArgErr()
+			}
+			mtu, err := strconv.ParseUint(d.Val(), 10, 16)
+			if err != nil {
+				return nil, d.Errf("invalid mtu: %v", err)
+			}
+			v := uint16(mtu)
+			node.MTU = &v
+
+		case "no_userspace":
+			val, err := parseBoolArg(d)
+			if err != nil {
+				return nil, err
+			}
+			node.NoUserspace = val
+
+		case "disable_client_routes":
+			val, err := parseBoolArg(d)
+			if err != nil {
+				return nil, err
+			}
+			node.DisableClientRoutes = val
+
+		case "disable_ipv6":
+			val, err := parseBoolArg(d)
+			if err != nil {
+				return nil, err
+			}
+			node.DisableIPv6 = val
 
 		case "block_inbound":
 			if !d.NextArg() {
@@ -391,12 +508,66 @@ func parseNode(d *caddyfile.Dispenser) (*Node, error) {
 			}
 			node.BlockInbound = &val
 
+		case "block_lan_access":
+			val, err := parseBoolArg(d)
+			if err != nil {
+				return nil, err
+			}
+			node.BlockLANAccess = val
+
+		case "dns_labels":
+			labels := d.RemainingArgs()
+			if len(labels) == 0 {
+				return nil, d.ArgErr()
+			}
+			node.DNSLabels = labels
+
+		case "preallocated_buffers_per_pool":
+			v, err := parseUint32Arg(d)
+			if err != nil {
+				return nil, err
+			}
+			node.PreallocatedBuffersPerPool = &v
+
+		case "max_batch_size":
+			v, err := parseUint32Arg(d)
+			if err != nil {
+				return nil, err
+			}
+			node.MaxBatchSize = &v
+
 		default:
 			return nil, d.Errf("unrecognized node option: %s", d.Val())
 		}
 	}
 
 	return node, nil
+}
+
+// parseBoolArg reads and parses a single boolean argument for the current directive.
+func parseBoolArg(d *caddyfile.Dispenser) (bool, error) {
+	directive := d.Val()
+	if !d.NextArg() {
+		return false, d.ArgErr()
+	}
+	val, err := strconv.ParseBool(d.Val())
+	if err != nil {
+		return false, d.Errf("invalid %s: %v", directive, err)
+	}
+	return val, nil
+}
+
+// parseUint32Arg reads and parses a single uint32 argument for the current directive.
+func parseUint32Arg(d *caddyfile.Dispenser) (uint32, error) {
+	directive := d.Val()
+	if !d.NextArg() {
+		return 0, d.ArgErr()
+	}
+	n, err := strconv.ParseUint(d.Val(), 10, 32)
+	if err != nil {
+		return 0, d.Errf("invalid %s: %v", directive, err)
+	}
+	return uint32(n), nil
 }
 
 var (

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -94,6 +94,8 @@ func TestParseGlobalOption_MultipleNodes(t *testing.T) {
 	assert.Equal(t, "https://custom.example.com:443", api.ManagementURL)
 }
 
+// TestParseGlobalOption_NodeAllOptions verifies that every supported node
+// directive is parsed into the corresponding Node field.
 func TestParseGlobalOption_NodeAllOptions(t *testing.T) {
 	app := parseAndDecode(t, `netbird {
 		management_url https://api.netbird.io:443
@@ -102,9 +104,23 @@ func TestParseGlobalOption_NodeAllOptions(t *testing.T) {
 		node full {
 			management_url https://mgmt.example.com:443
 			setup_key node-key
+			jwt_token my-jwt
+			private_key my-priv
 			hostname my-caddy
 			pre_shared_key secret
+			log_level debug
+			config_path /etc/netbird/config.json
+			state_path /var/lib/netbird/state.json
 			wireguard_port 51821
+			mtu 1400
+			no_userspace true
+			disable_client_routes true
+			disable_ipv6 true
+			block_inbound false
+			block_lan_access true
+			dns_labels app db cache
+			preallocated_buffers_per_pool 512
+			max_batch_size 128
 		}
 	}`)
 
@@ -112,10 +128,28 @@ func TestParseGlobalOption_NodeAllOptions(t *testing.T) {
 	require.NotNil(t, node)
 	assert.Equal(t, "https://mgmt.example.com:443", node.ManagementURL)
 	assert.Equal(t, "node-key", node.SetupKey)
+	assert.Equal(t, "my-jwt", node.JWTToken)
+	assert.Equal(t, "my-priv", node.PrivateKey)
 	assert.Equal(t, "my-caddy", node.Hostname)
 	assert.Equal(t, "secret", node.PreSharedKey)
+	assert.Equal(t, "debug", node.LogLevel)
+	assert.Equal(t, "/etc/netbird/config.json", node.ConfigPath)
+	assert.Equal(t, "/var/lib/netbird/state.json", node.StatePath)
 	require.NotNil(t, node.WireguardPort)
 	assert.Equal(t, 51821, *node.WireguardPort)
+	require.NotNil(t, node.MTU)
+	assert.Equal(t, uint16(1400), *node.MTU)
+	assert.True(t, node.NoUserspace)
+	assert.True(t, node.DisableClientRoutes)
+	assert.True(t, node.DisableIPv6)
+	require.NotNil(t, node.BlockInbound)
+	assert.False(t, *node.BlockInbound)
+	assert.True(t, node.BlockLANAccess)
+	assert.Equal(t, []string{"app", "db", "cache"}, node.DNSLabels)
+	require.NotNil(t, node.PreallocatedBuffersPerPool)
+	assert.Equal(t, uint32(512), *node.PreallocatedBuffersPerPool)
+	require.NotNil(t, node.MaxBatchSize)
+	assert.Equal(t, uint32(128), *node.MaxBatchSize)
 }
 
 func TestParseGlobalOption_UnknownOption(t *testing.T) {
@@ -146,6 +180,8 @@ func TestParseGlobalOption_InvalidWireguardPort(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestValidate covers node credential and management URL validation,
+// including the setup_key, jwt_token, and private_key alternatives.
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -180,12 +216,26 @@ func TestValidate(t *testing.T) {
 			wantErr: ErrMissingManagementURL,
 		},
 		{
-			name: "missing setup_key",
+			name: "missing credentials",
 			app: App{
 				DefaultManagementURL: "https://api.netbird.io",
 				Nodes:                map[string]*Node{"web": {}},
 			},
-			wantErr: ErrMissingSetupKey,
+			wantErr: ErrMissingCredentials,
+		},
+		{
+			name: "jwt_token satisfies credentials",
+			app: App{
+				DefaultManagementURL: "https://api.netbird.io",
+				Nodes:                map[string]*Node{"web": {JWTToken: "jwt"}},
+			},
+		},
+		{
+			name: "private_key satisfies credentials",
+			app: App{
+				DefaultManagementURL: "https://api.netbird.io",
+				Nodes:                map[string]*Node{"web": {PrivateKey: "priv"}},
+			},
 		},
 		{
 			name: "no nodes is valid",
@@ -211,11 +261,13 @@ func TestResolveNode(t *testing.T) {
 	app := &App{
 		DefaultManagementURL: "https://default.example.com",
 		DefaultSetupKey:      "default-key",
+		LogLevel:             "debug",
 		Nodes: map[string]*Node{
 			"custom": {
 				ManagementURL: "https://custom.example.com",
 				SetupKey:      "custom-key",
 				Hostname:      "my-host",
+				LogLevel:      "warn",
 			},
 			"partial": {
 				Hostname: "partial-host",
@@ -228,6 +280,7 @@ func TestResolveNode(t *testing.T) {
 		assert.Equal(t, "https://custom.example.com", node.ManagementURL)
 		assert.Equal(t, "custom-key", node.SetupKey)
 		assert.Equal(t, "my-host", node.Hostname)
+		assert.Equal(t, "warn", node.LogLevel)
 	})
 
 	t.Run("partial node inherits defaults", func(t *testing.T) {
@@ -235,6 +288,7 @@ func TestResolveNode(t *testing.T) {
 		assert.Equal(t, "https://default.example.com", node.ManagementURL)
 		assert.Equal(t, "default-key", node.SetupKey)
 		assert.Equal(t, "partial-host", node.Hostname)
+		assert.Equal(t, "debug", node.LogLevel)
 	})
 
 	t.Run("unknown node gets defaults", func(t *testing.T) {


### PR DESCRIPTION
Add per-node Caddyfile directives for every configurable embed.Options field: jwt_token, private_key, log_level, config_path, state_path, mtu, no_userspace, disable_client_routes, disable_ipv6, block_lan_access, dns_labels, and the process-global performance knobs (preallocated_buffers_per_pool, max_batch_size), alongside the existing management_url, setup_key, hostname, pre_shared_key, wireguard_port, and block_inbound.

Validation now accepts any one of setup_key, jwt_token, or private_key as the node credential (ErrMissingSetupKey -> ErrMissingCredentials). README and parse/validate tests updated to cover the new options.

The reasoning for this PR is that I'm using an ephemeral setup key and everytime I restart caddy, it gets assigned a new random hostname. So this allows to set a fixed DNS label that I can reach or store the state inside a specific directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for JWT tokens and private keys as alternative node authentication methods.
  * Expanded per-node configuration with logging, config/state paths, MTU and WireGuard settings, networking controls, DNS labels, and performance tuning.
  * Added validation requiring at least one supported credential per node.

* **Documentation**
  * Updated the Node options documentation with the new authentication methods and configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->