### PR TITLE
Bump netbird to v0.77.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/caddyserver/caddy/v2 v2.11.4
 	github.com/mholt/caddy-l4 v0.0.0-20260216070754-eca560d759c9
-	github.com/netbirdio/netbird v0.76.3-0.20260807190256-b961f93a3310
+	github.com/netbirdio/netbird v0.77.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.28.0
@@ -277,4 +277,4 @@ replace github.com/dexidp/dex/api/v2 => github.com/netbirdio/dex/api/v2 v2.0.0-2
 
 replace github.com/mailru/easyjson => github.com/netbirdio/easyjson v0.9.0
 
-replace github.com/wailsapp/wails/v3 => github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260807055527-fc03f984d701
+replace github.com/wailsapp/wails/v3 => github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260810103952-24e716aea4db

--- a/go.sum
+++ b/go.sum
@@ -461,8 +461,8 @@ github.com/netbirdio/ice/v4 v4.0.0-20250908184934-6202be846b51 h1:Ov4qdafATOgGMB
 github.com/netbirdio/ice/v4 v4.0.0-20250908184934-6202be846b51/go.mod h1:ZSIbPdBn5hePO8CpF1PekH2SfpTxg1PDhEwtbqZS7R8=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260416123949-2355d972be42 h1:F3zS5fT9xzD1OFLfcdAE+3FfyiwjGukF1hvj0jErgs8=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260416123949-2355d972be42/go.mod h1:n47r67ZSPgwSmT/Z1o48JjZQW9YJ6m/6Bd/uAXkL3Pg=
-github.com/netbirdio/netbird v0.76.3-0.20260807190256-b961f93a3310 h1:mpEjhu7q1lI/BxhzhbNbx7h/IC9z+/On2KgTisx2k1Q=
-github.com/netbirdio/netbird v0.76.3-0.20260807190256-b961f93a3310/go.mod h1:6ofUCco+Myx85bpWKialEdPO//XdHuTvBxT4PpjUG3E=
+github.com/netbirdio/netbird v0.77.0 h1:FsZeT7shLazmyF9wjDt/4+HoBdZdfdVluD7eDDFRAdE=
+github.com/netbirdio/netbird v0.77.0/go.mod h1:LlTSuwk0F94rpMUt936KvMq6o3glHYOevyVqxqKxBfA=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45 h1:ujgviVYmx243Ksy7NdSwrdGPSRNE3pb8kEDSpH0QuAQ=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45/go.mod h1:5/sjFmLb8O96B5737VCqhHyGRzNFIaN/Bu7ZodXc3qQ=
 github.com/netbirdio/wireguard-go v0.0.0-20260628102922-2834bebf6c1a h1:3CWK+yTvRKOcC0Q8VCTGy4l60TEb27CQVS7LkMxwjmw=


### PR DESCRIPTION
Automated NetBird dependency update to v0.77.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the NetBird integration to the stable 0.77.0 release.
  * Updated the Wails v3 integration to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->